### PR TITLE
become_user to actual user specified

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,9 @@
 ---
 # main tasks file for fubarhouse-rust
+- name: "Include setup tasks"
+  include_tasks: setup.yml
+
 - block:
-    - name: "Include setup tasks"
-      include_tasks: setup.yml
 
     - name: "Include tasks to clean installation"
       include_tasks: cleanup.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,42 +1,45 @@
 ---
 # main tasks file for fubarhouse-rust
+- block:
+    - name: "Include setup tasks"
+      include_tasks: setup.yml
 
-- name: "Include setup tasks"
-  include_tasks: setup.yml
+    - name: "Include tasks to clean installation"
+      include_tasks: cleanup.yml
+      when: rust_install_clean|bool == true
 
-- name: "Include tasks to clean installation"
-  include_tasks: cleanup.yml
-  when: rust_install_clean|bool == true
+    - name: "Install from installer"
+      include_tasks: installer.yml
+      when:
+        - ((build_rust_from_source|bool == false) and
+          (rust_version_requirement not in rust_preinstall_version_r.stdout)) or
+          (rust_update|bool == true)
 
-- name: "Install from installer"
-  include_tasks: installer.yml
-  when:
-    - ((build_rust_from_source|bool == false) and
-      (rust_version_requirement not in rust_preinstall_version_r.stdout)) or
-      (rust_update|bool == true)
+    - name: "Install from source"
+      include_tasks: source.yml
+      when:
+        - build_rust_from_source|bool == true
+        - rust_version_requirement not in rust_preinstall_version_s.stdout
 
-- name: "Install from source"
-  include_tasks: source.yml
-  when:
-    - build_rust_from_source|bool == true
-    - rust_version_requirement not in rust_preinstall_version_s.stdout
+    - name: "Ensure shell profiles are present"
+      lineinfile:
+        dest: "{{ item[0].stat.path }}"
+        regexp: "{{ item[1].regex }}"
+        line: "{{ item[1].lineinfile }}"
+        state: present
+      with_nested:
+      - "{{ stat_shell_profiles.results }}"
+      - "{{ shell_exports }}"
+      when:
+      - shell_profiles is defined
+      - shell_exports is defined
+      - item[0].stat.exists|bool == true
 
-- name: "Ensure shell profiles are present"
-  lineinfile:
-    dest: "{{ item[0].stat.path }}"
-    regexp: "{{ item[1].regex }}"
-    line: "{{ item[1].lineinfile }}"
-    state: present
-  with_nested:
-  - "{{ stat_shell_profiles.results }}"
-  - "{{ shell_exports }}"
-  when:
-  - shell_profiles is defined
-  - shell_exports is defined
-  - item[0].stat.exists|bool == true
+    - name: "Include verification tasks"
+      include_tasks: verify.yml
 
-- name: "Include verification tasks"
-  include_tasks: verify.yml
+    - name: "Include tasks for Cargo"
+      include_tasks: cargo.yml
 
-- name: "Include tasks for Cargo"
-  include_tasks: cargo.yml
+  become: True
+  become_user: "{{ fubarhouse_user }}"

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -1,6 +1,11 @@
 ---
 # setup tasks file for fubarhouse-rust
 
+- name: "Rust | Debug user"
+  become: True
+  become_user: "{{ fubarhouse_user }}"
+  shell: whoami
+
 - name: "Rust | Look for cURL"
   shell: which curl
   register: rust_which_curl

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -1,11 +1,6 @@
 ---
 # setup tasks file for fubarhouse-rust
 
-- name: "Rust | Debug user"
-  become: True
-  become_user: "{{ fubarhouse_user }}"
-  shell: whoami
-
 - name: "Rust | Look for cURL"
   shell: which curl
   register: rust_which_curl

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -34,15 +34,23 @@
 
 - name: "Rust | Define user variable for ssh use"
   set_fact:
-    fubarhouse_user: "{{ ansible_ssh_user }}"
-  when: ansible_ssh_user is defined and fubarhouse_user is not defined
+    fubarhouse_user: "{{ ansible_user }}"
+  when: ansible_user is defined and fubarhouse_user is not defined and ansible_env.USER == ansible_user
+
+- name: "Rust | Define user variable when becoming a different user"
+  set_fact:
+    fubarhouse_user: "{{ ansible_env.USER }}"
+  when: ansible_user is defined and fubarhouse_user is not defined and ansible_env.USER != ansible_user
+
 
 - name: "Rust | Define user variable for non-ssh use"
   set_fact:
     fubarhouse_user: "{{ ansible_user_id }}"
-  when: ansible_ssh_user is not defined and fubarhouse_user is not defined
+  when: ansible_user is not defined and fubarhouse_user is not defined
 
 - name: "Rust | Get $HOME"
+  become: True
+  become_user: "{{ fubarhouse_user }}"
   shell: "echo $HOME"
   register: shell_home_dir
   changed_when: false


### PR DESCRIPTION
This fixes the ability to have ansible always running as root, for example, while still allowing this role to override to install rust as another user