### PR TITLE
Install the required rust toolchain version

### DIFF
--- a/tasks/installer.yml
+++ b/tasks/installer.yml
@@ -3,3 +3,9 @@
 - name: "Rust | Install"
   shell: "curl https://sh.rustup.rs -sSf | sh -s -- -y"
   changed_when: false
+
+- name: "Rust | Install toolchain"
+  shell: "{{ fubarhouse_user_dir }}/.cargo/bin/rustup toolchain install {{ rust_version }}"
+  register: rustup_toolchain
+  changed_when: '"installed" in rustup_toolchain.stdout'
+  when: rust_version is defined


### PR DESCRIPTION
I had a problem when using rust installer that the version of tool chain I specified in rust_version was simply ignored. I think we are missing an additional action in installer.yml which takes care of installing particular rust toolchain version if rust_version is defined. Though I might have misunderstood how it is supposed to work. In any case following fix worked for me.